### PR TITLE
Fix inducing point extraction and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ This repository provides a PyTorch-based implementation of a predictive control 
 ### 1. Install dependencies:
 ```bash
 pip install -r requirements.txt
+```
+
+### 2. Train and evaluate the model
+```bash
+python main.py
+```

--- a/train.py
+++ b/train.py
@@ -12,12 +12,14 @@ import os
 
 def get_inducing_points(lstm_model, train_dataset, num_inducing_points, output_dim, device):
     print("Collecting latent representations for KMeans...")
+    lstm_model.eval()
     with torch.no_grad():
         latent_all = []
         for bx, _ in DataLoader(train_dataset, batch_size=256):
             latent = lstm_model(bx.to(device))
             latent_all.append(latent.cpu().numpy())
         latent_all = np.vstack(latent_all)
+    lstm_model.train()
     print(f"Latent shape: {latent_all.shape}")
     kmeans = KMeans(n_clusters=num_inducing_points, random_state=SEED).fit(latent_all)
     inducing_points = torch.FloatTensor(kmeans.cluster_centers_).to(device)


### PR DESCRIPTION
## Summary
- ensure dropout doesn't corrupt initial inducing points
- fix truncated README instructions

## Testing
- `python -m py_compile config.py dataset.py models.py train.py eval.py main.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68454e8d4a98832db115d08f49447202